### PR TITLE
add safeOn cli option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,18 @@ Coming back from holidays was hard. So I spent some time with a little game (ton
 
 ## Requirements
 
-Python and the serial library:
+Python and the serial and click libraries:
 
 	pip install pyserial
+	pip install click
 
 Shortcomings:
 
  * Cannot read current consumption. (Function implemented, does not seem to work)
  * Always saves to memory 1. (Function implemented, POWER SUPPLY not behaving as expected. Restores all memories correctly though.
  * The physical buttons are blocked for a while after connecting.
+ * The safeON method does not select channels.
+ * The safe current and voltage values are hardcoded in Tenma72_2540 class. To use different values, either overwrite them in tenmaDcLib.py, or use safeC and safeV cli args.
 
 
 ## Usage examples
@@ -66,3 +69,11 @@ For example: 2.2 Amperes 5V:
 A very simple GTK indicator to control a tenma DC power supply from a graphical desktop. Provides ON, OFF and RESET facilities. Simply start it with:
 
 	./gtkIndicator.py
+
+### Safely turn on while checking current (3A) and voltage (12V) before turning on
+
+    python tenmaControl.py --safeOn /dev/ttyUSB0
+
+### Safely turn on while checking custom current (safeC=2000 mA) and voltage (safeV=5000 mV) before turning on
+
+    python tenmaControl.py --safeOn --safeC 2000 --safeV 5000 /dev/ttyUSB0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyserial
+click

--- a/tenma/tenmaControl.py
+++ b/tenma/tenmaControl.py
@@ -27,6 +27,8 @@ def main():
     parser.add_argument('device', default="/dev/ttyUSB0")
     parser.add_argument('-v', '--voltage', help='set mV', required=False, type=int)
     parser.add_argument('-c', '--current', help='set mA', required=False, type=int)
+    parser.add_argument('--safeC', help='set safety current limit to mA', required=False, type=int)
+    parser.add_argument('--safeV', help='set safety voltage limit to mV', required=False, type=int)
     parser.add_argument('-C', '--channel', help='channel to set (if not provided, 1 will be used)', required=False, type=int, default=1)
     parser.add_argument('-s', '--save', help='Save current configuration to Memory', required=False, type=int)
     parser.add_argument('-r', '--recall', help='Load configuration from Memory', required=False, type=int)
@@ -80,6 +82,16 @@ def main():
             if VERB:
                 print("Setting current to ", args["current"])
             T.setCurrent(args["channel"], args["current"])
+
+        if args["safeC"]:
+            if VERB:
+                print("Setting safe current to ", args["safeC"])
+            T.setSafeCurrent(args["safeC"])
+
+        if args["safeV"]:
+            if VERB:
+                print("Setting safe voltage to ", args["safeV"])
+            T.setSafeCurrent(args["safeV"])
 
         if args["save"]:
             if VERB:

--- a/tenma/tenmaControl.py
+++ b/tenma/tenmaControl.py
@@ -73,16 +73,6 @@ def main():
                 print("Disable overvoltage protection")
             T.setOVP(False)
 
-        if args["voltage"]:
-            if VERB:
-                print("Setting voltage to ", args["voltage"])
-            T.setVoltage(args["channel"], args["voltage"])
-
-        if args["current"]:
-            if VERB:
-                print("Setting current to ", args["current"])
-            T.setCurrent(args["channel"], args["current"])
-
         if args["safeC"]:
             if VERB:
                 print("Setting safe current to ", args["safeC"])
@@ -92,6 +82,16 @@ def main():
             if VERB:
                 print("Setting safe voltage to ", args["safeV"])
             T.setSafeCurrent(args["safeV"])
+
+        if args["voltage"]:
+            if VERB:
+                print("Setting voltage to ", args["voltage"])
+            T.setVoltage(args["channel"], args["voltage"])
+
+        if args["current"]:
+            if VERB:
+                print("Setting current to ", args["current"])
+            T.setCurrent(args["channel"], args["current"])
 
         if args["save"]:
             if VERB:

--- a/tenma/tenmaControl.py
+++ b/tenma/tenmaControl.py
@@ -36,6 +36,7 @@ def main():
     parser.add_argument('--ovp-enable', help='Enable overvoltage protection', required=False, action="store_true", default=False)
     parser.add_argument('--ovp-disable', help='Disable overvoltage pritection', required=False, action="store_true", default=False)
     parser.add_argument('--on', help='Set output to ON', action="store_true", default=False)
+    parser.add_argument('--safeOn', help='Safely set output to ON', action="store_true", default=False)
     parser.add_argument('--off', help='Set output to OFF', action="store_true", default=False)
     parser.add_argument('--verbose', help='Chatty program', action="store_true", default=False)
     parser.add_argument('--debug', help='print serial commands', action="store_true", default=False)
@@ -102,6 +103,11 @@ def main():
             if VERB:
                 print("Turning OUTPUT OFF")
             T.OFF()
+
+        if args["safeOn"]:
+            if VERB:
+                print("Safely turning OUTPUT ON")
+            T.safeON()
 
         if args["on"]:
             if VERB:

--- a/tenma/tenmaDcLib.py
+++ b/tenma/tenmaDcLib.py
@@ -173,7 +173,7 @@ class Tenma72_2540:
                 safe_mA=self.SAFE_MA
             ))
             if not click.confirm('Do you want to continue?', default=True):
-                print("Aborting.")
+                print("Aborting. If you want, use --safeC to allow for a different safe current.")
                 return
 
         command = "ISET{channel}:{amperes:.3f}"
@@ -230,7 +230,7 @@ class Tenma72_2540:
                 safe_mV=self.SAFE_MV
             ))
             if not click.confirm('Do you want to continue?', default=True):
-                print("Aborting.")
+                print("Aborting. If you want, use --safeV to allow for a different safe Voltage.")
                 return
 
         command = "VSET{channel}:{volt:.2f}"
@@ -391,7 +391,7 @@ class Tenma72_2540:
                 safe_mA=self.SAFE_MA
             ))
             if not click.confirm('Do you want to continue?', default=True):
-                print("Aborting.")
+                print("Aborting. Either use --current to set a new output current or use --safeC to allow for a different safe current")
                 return
 
         # ToDo: allow channels other than "1"
@@ -402,7 +402,7 @@ class Tenma72_2540:
                 safe_mV=self.SAFE_MV
             ))
             if not click.confirm('Do you want to continue?', default=True):
-                print("Aborting.")
+                print("Aborting. Either use --voltage to set a new output voltage or use --safeV to allow for a different safe voltage")
                 return
 
         command = "OUT1"

--- a/tenma/tenmaDcLib.py
+++ b/tenma/tenmaDcLib.py
@@ -45,6 +45,12 @@ class Tenma72_2540:
         self.SAFE_MV = 12000
         self.DEBUG = debug
 
+    def setSafeCurrent(self, mA):
+        self.SAFE_MA = mA
+
+    def setSafeVoltage(self, mV):
+        self.SAFE_MV
+
     def setPort(self, serialPort):
         self.ser = serial.Serial(port=serialPort,
                                  baudrate=9600,

--- a/tenma/tenmaDcLib.py
+++ b/tenma/tenmaDcLib.py
@@ -172,7 +172,7 @@ class Tenma72_2540:
                 mA=mA,
                 safe_mA=self.SAFE_MA
             ))
-            if not click.confirm('Do you want to continue?', default=True):
+            if not click.confirm('Do you want to continue?', default=False):
                 print("Aborting. If you want, use --safeC to allow for a different safe current.")
                 return
 
@@ -229,7 +229,7 @@ class Tenma72_2540:
                 mV=mV,
                 safe_mV=self.SAFE_MV
             ))
-            if not click.confirm('Do you want to continue?', default=True):
+            if not click.confirm('Do you want to continue?', default=False):
                 print("Aborting. If you want, use --safeV to allow for a different safe Voltage.")
                 return
 
@@ -390,7 +390,7 @@ class Tenma72_2540:
                 readcurrent=int(readcurrent*1000),
                 safe_mA=self.SAFE_MA
             ))
-            if not click.confirm('Do you want to continue?', default=True):
+            if not click.confirm('Do you want to continue?', default=False):
                 print("Aborting. Either use --current to set a new output current or use --safeC to allow for a different safe current")
                 return
 
@@ -401,7 +401,7 @@ class Tenma72_2540:
                 readvolt=int(readvolt*1000),
                 safe_mV=self.SAFE_MV
             ))
-            if not click.confirm('Do you want to continue?', default=True):
+            if not click.confirm('Do you want to continue?', default=False):
                 print("Aborting. Either use --voltage to set a new output voltage or use --safeV to allow for a different safe voltage")
                 return
 

--- a/tenma/tenmaDcLib.py
+++ b/tenma/tenmaDcLib.py
@@ -49,7 +49,7 @@ class Tenma72_2540:
         self.SAFE_MA = mA
 
     def setSafeVoltage(self, mV):
-        self.SAFE_MV
+        self.SAFE_MV = mV
 
     def setPort(self, serialPort):
         self.ser = serial.Serial(port=serialPort,


### PR DESCRIPTION
here at SG we prepared a desktop-server with a hw setup that is meant to be shared by the whole team.

because the dev is not necessarily sitting in front of the power supply, we thought it would be useful to have some sort of safety mechanism that would not allow them to accidentally turn it on when current or voltage was set above the board's nominal values.

I added some logic that allows for that verification, as long as the user chooses `--safeOn` instead of `--on`

It's still not 100%, mainly because:
 - the `safeON()` function (in `tenmaDcLib.py`) does not check for channels.
 - safe current (3000) and safe voltage values (12000) are hardcoded as `Tenma72_2540` class members... they can be overwritten with `--safeC` and `--safeV`, but I'm still not sure that's the most elegant approach

anyways, I thought I should submit a PR and get some feedback