### PR TITLE
Add support for Tenma 72-13360

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Supports the following models with predefined limits:
     * 72-2940 -> Set as manufacturer manual (not tested)
     * 72-13320 -> Set as manufacturer manual (not tested)
     * 72-13330 -> Tested on HW (thomas-phillips-nz)
+    * 72-13360 -> Tested on HW (Sebastian Norlin)
 
 Also, even if not described, should support [Koradka
 models](https://sigrok.org/wiki/Korad_KAxxxxP_series) and other Velleman units

--- a/tenma/tenmaControl.py
+++ b/tenma/tenmaControl.py
@@ -22,9 +22,9 @@ import argparse
 # TODO this is just a trick so tenmaControl runs cleanly from both the source tree
 # and the pip installation
 try:
-    from tenma.tenmaDcLib import instantiate_tenma_class_from_device_response, TenmaException, TenmaProtocol
+    from tenma.tenmaDcLib import instantiate_tenma_class_from_device_response, TenmaException
 except Exception:
-    from tenmaDcLib import instantiate_tenma_class_from_device_response, TenmaException, TenmaProtocol
+    from tenmaDcLib import instantiate_tenma_class_from_device_response, TenmaException
 
 
 def main():
@@ -115,12 +115,12 @@ def main():
         if args["voltage"]:
             if VERB:
                 print("Setting voltage to ", args["voltage"])
-                T.setVoltage(args["channel"], args["voltage"])
+            T.setVoltage(args["channel"], args["voltage"])
 
         if args["current"]:
             if VERB:
                 print("Setting current to ", args["current"])
-                T.setCurrent(args["channel"], args["current"])
+            T.setCurrent(args["channel"], args["current"])
 
         if args["save"]:
             if VERB:

--- a/tenma/tenmaControl.py
+++ b/tenma/tenmaControl.py
@@ -115,17 +115,11 @@ def main():
         if args["voltage"]:
             if VERB:
                 print("Setting voltage to ", args["voltage"])
-            if T.TENMA_PROTOCOL == TenmaProtocol.RS232:
-                T.setVoltage(args["channel"])
-            else:
                 T.setVoltage(args["channel"], args["voltage"])
 
         if args["current"]:
             if VERB:
                 print("Setting current to ", args["current"])
-            if T.TENMA_PROTOCOL == TenmaProtocol.RS232:
-                T.setCurrent(args["channel"])
-            else:
                 T.setCurrent(args["channel"], args["current"])
 
         if args["save"]:
@@ -164,16 +158,11 @@ def main():
         if args["runningCurrent"]:
             if VERB:
                 print("Retrieving running Current")
-            if T.TENMA_PROTOCOL == TenmaProtocol.RS232:
-                print(T.runningCurrent())
-            else:
-                print(T.runningCurrent(args["channel"]))
+            print(T.runningCurrent(args["channel"]))
 
         if args["runningVoltage"]:
             if VERB:
                 print("Retrieving running Voltage")
-            if T.TENMA_PROTOCOL == TenmaProtocol.RS232:
-                print(T.runningVoltage())
             print(T.runningVoltage(args["channel"]))
 
     except TenmaException as e:

--- a/tenma/tenmaControl.py
+++ b/tenma/tenmaControl.py
@@ -22,9 +22,9 @@ import argparse
 # TODO this is just a trick so tenmaControl runs cleanly from both the source tree
 # and the pip installation
 try:
-    from tenma.tenmaDcLib import instantiate_tenma_class_from_device_response, TenmaException
+    from tenma.tenmaDcLib import instantiate_tenma_class_from_device_response, TenmaException, TenmaProtocol
 except Exception:
-    from tenmaDcLib import instantiate_tenma_class_from_device_response, TenmaException
+    from tenmaDcLib import instantiate_tenma_class_from_device_response, TenmaException, TenmaProtocol
 
 
 def main():
@@ -115,12 +115,18 @@ def main():
         if args["voltage"]:
             if VERB:
                 print("Setting voltage to ", args["voltage"])
-            T.setVoltage(args["channel"], args["voltage"])
+            if T.TENMA_PROTOCOL == TenmaProtocol.RS232:
+                T.setVoltage(args["channel"])
+            else:
+                T.setVoltage(args["channel"], args["voltage"])
 
         if args["current"]:
             if VERB:
                 print("Setting current to ", args["current"])
-            T.setCurrent(args["channel"], args["current"])
+            if T.TENMA_PROTOCOL == TenmaProtocol.RS232:
+                T.setCurrent(args["channel"])
+            else:
+                T.setCurrent(args["channel"], args["current"])
 
         if args["save"]:
             if VERB:
@@ -158,11 +164,16 @@ def main():
         if args["runningCurrent"]:
             if VERB:
                 print("Retrieving running Current")
-            print(T.runningCurrent(args["channel"]))
+            if T.TENMA_PROTOCOL == TenmaProtocol.RS232:
+                print(T.runningCurrent())
+            else:
+                print(T.runningCurrent(args["channel"]))
 
         if args["runningVoltage"]:
             if VERB:
                 print("Retrieving running Voltage")
+            if T.TENMA_PROTOCOL == TenmaProtocol.RS232:
+                print(T.runningVoltage())
             print(T.runningVoltage(args["channel"]))
 
     except TenmaException as e:

--- a/tenma/tenmaDcLib.py
+++ b/tenma/tenmaDcLib.py
@@ -38,8 +38,10 @@
 import serial
 import time
 
+
 class TenmaException(Exception):
     pass
+
 
 def instantiate_tenma_class_from_device_response(device, debug=False):
     """
@@ -73,7 +75,7 @@ def findSubclassesRecursively(cls):
     """
     for subclass in cls.__subclasses__():
         yield from findSubclassesRecursively(subclass)
-        yield subclass  
+        yield subclass
 
 class TenmaSerialHandler(object):
     """
@@ -533,8 +535,6 @@ class Tenma72Base(object):
         command = "OUT0"
         self._sendCommand(command)
 
-
-
     def setLock(self, enable=True):
         """
             Set the front-panel lock on or off
@@ -662,18 +662,6 @@ class Tenma72Base(object):
 
             :param channel: Channel to decrease the current for
             :raises NotImplementedError Not implemented in this base class
-        """
-        raise NotImplementedError("Not supported by all models")
-    
-    def setVoltagePriority(self):
-        """
-            Prioritize voltage
-        """
-        raise NotImplementedError("Not supported by all models")
-
-    def setCurrentPriority(self):
-        """
-            Prioritize current
         """
         raise NotImplementedError("Not supported by all models")
 


### PR DESCRIPTION
Adds a Tenam_72-13360 class that controls 72-13360 PSU

This is fully backwards compatible. The main change is that 72-13360 has one channel and does not specify it in the messages.

Notes on the implementation: The goal of the current implementation was to add 72-13360 support while having minimum impact on the existing code.

The place where the current implementation gets a bit ugly is readVoltage and readCurrent as they need to take a channel argument for the feedback mechanism for setCurrent/setVoltage to work. I tried to modify the old code as little as possible but can easily for example call readCurrent() rather than readCurrent(channel) in the setCurrent function if the channel is "" if you prefer.