### PR TITLE
Tested HW support for 72-2540, add pytest tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tests/.coverage
 tests/coverage.xml
 tests/htmlcov/
 tests/test-results/
+.vscode

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Provides two basic controllers (tested on Linux) for a TENMA DC power supply via
 
 ## What is this?
 
-A small command line program / library to setup a Tenma 72-XXXX DC POWER SUPPLY from your computer via SERIAL. 
+A small command line program / library to setup a Tenma 72-XXXX DC POWER SUPPLY from your computer via SERIAL.
 
 Supports the following models with predefined limits:
 
@@ -104,3 +104,36 @@ Or directly from the source code via:
 
 ## Known Shortcomings:
  * The physical buttons are blocked for a while after connecting.
+
+# Testing:
+This project contains some [pytest](https://pytest.org) tests to make it easier to add support for new power supply variants, and validate changes to the code.
+
+These tests live under the `tests/` directory in `test_tenma.py`.  There are two environment variables used by the tests:
+ * TENMA_MODEL - set this to the MATCH_STR of the power supply you're testing. Defaults to 72-2540
+ * TENMA_PORT - Optional: set this to the COM/tty port on you PC connected to the power supply. Defaults to auto-finding the port
+
+The tests were written against 72-2540, there are no extra tests for the 72-133XX models (yet). We curerntly test:
+ * PSU init/version string
+ * Set/get voltage
+ * Set/get current
+ * Save/recall memory in all slots
+ * Set/unset beep
+ * Turn output on/off
+
+**Note: Before testing, disconnect everything from the power supply. We try to test as safely as possible, but no promises are made**
+
+First, install pytest:
+
+    pip install pytest
+
+Then you can run the tests from the root directory of the repo:
+
+    python -m pytest
+
+You can set the environment variables when you run the test:
+
+    # Windows:
+    $env:TENMA_MODEL='72-2550'; $env:TENMA_PORT='COM7'; python -m pytest
+
+    # Linux:
+    TENMA_MODEL='72-2550' TENMA_PORT='COM7' python -m pytest

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Supports the following models with predefined limits:
 
     * 72-2545 -> Tested on HW (@kxtells)
     * 72-2535 -> Set as manufacturer manual (not tested)
-    * 72-2540 -> Set as manufacturer manual (not tested)
+    * 72-2540 -> Tested on HW (thomas-phillips-nz)
     * 72-2550 -> Tested on HW (@kxtells)
     * 72-2705 -> Tested on HW (@ollie1400)
     * 72-2930 -> Set as manufacturer manual (not tested)

--- a/tenma/tenmaDcLib.py
+++ b/tenma/tenmaDcLib.py
@@ -23,7 +23,7 @@
 
      * 72_2545 -> Tested on HW
      * 72_2535 -> Set as manufacturer manual (not tested)
-     * 72_2540 -> Set as manufacturer manual (not tested)
+     * 72_2540 -> Tested on HW
      * 72_2550 -> Tested on HW
      * 72-2705 -> Tested on HW
      * 72_2930 -> Set as manufacturer manual (not tested)
@@ -688,9 +688,9 @@ class Tenma72_2540(Tenma72Base):
     #: Only 4 physical buttons. But 5 memories are available
     NCONFS = 5
     #:
-    MAX_MA = 5000
+    MAX_MA = 5100
     #:
-    MAX_MV = 30000
+    MAX_MV = 31000
 
 
 class Tenma72_2535(Tenma72Base):

--- a/tenma/tenmaDcLib.py
+++ b/tenma/tenmaDcLib.py
@@ -255,6 +255,20 @@ class Tenma72Base(object):
                     ma=mA,
                     max=self.MAX_MA))
 
+    def checkConf(self, conf):
+        """
+            Checks that the given Memory slot is valid for the power supply
+
+            :param conf: Memory slot to check
+            :raises TenmaException: If the Memory slot is outside the range for the power supply
+        """
+        conf = int(conf)
+        if conf > self.NCONFS or conf < 1:
+            raise TenmaException("Trying to use slot M{conf} with only {nconf} slots".format(
+                conf=conf,
+                nconf=self.NCONFS
+            ))
+
     def getVersion(self, serialEol=""):
         """
             Returns a single string with the version of the Tenma Device and Protocol user
@@ -425,12 +439,7 @@ class Tenma72Base(object):
             :param conf: Memory index to store to
             :raises TenmaException: If the memory index is outside the range
         """
-        if conf > self.NCONFS:
-            raise TenmaException("Trying to set M{conf} with only {nconf} slots".format(
-                conf=conf,
-                nconf=self.NCONFS
-            ))
-
+        self.checkConf(conf)
         command = "SAV{}".format(conf)
         self._sendCommand(command)
 
@@ -449,7 +458,7 @@ class Tenma72Base(object):
             :param conf: Memory index to store to
             :param channel: Channel with output to store
         """
-
+        self.checkConf(conf)
         self.OFF()
 
         # Read current voltage
@@ -475,12 +484,7 @@ class Tenma72Base(object):
         """
             Load existing configuration in Memory. Same as pressing any Mx button on the unit
         """
-
-        if conf > self.NCONFS:
-            raise TenmaException("Trying to recall M{conf} with only {nconf} confs".format(
-                conf=conf,
-                nconf=self.NCONFS
-            ))
+        self.checkConf(conf)
         self._sendCommand("RCL{}".format(conf))
 
     def setOCP(self, enable=True):
@@ -1337,7 +1341,8 @@ class Tenma72_13360_base(object):
             :param conf: Memory index to store to
             :raises TenmaException: If the memory index is outside the range
         """
-        if conf > self.NCONFS:
+        conf = int(conf)
+        if conf > self.NCONFS or conf < 1:
             raise TenmaException("Trying to set M{conf} with only {nconf} slots".format(
                 conf=conf,
                 nconf=self.NCONFS
@@ -1357,8 +1362,8 @@ class Tenma72_13360_base(object):
         """
             Load existing configuration in Memory. Same as pressing any Mx button on the unit
         """
-
-        if conf > self.NCONFS:
+        conf = int(conf)
+        if conf > self.NCONFS or conf < 1:
             raise TenmaException("Trying to recall M{conf} with only {nconf} confs".format(
                 conf=conf,
                 nconf=self.NCONFS

--- a/tenma/tenmaDcLib.py
+++ b/tenma/tenmaDcLib.py
@@ -219,7 +219,8 @@ class Tenma72Base(object):
             :param channel: Channel to check
             :raises TenmaException: If the channel is outside the range for the power supply
         """
-        if channel > self.NCHANNELS:
+        channel = int(channel)
+        if channel > self.NCHANNELS or channel < 1:
             raise TenmaException(
                 "Channel CH{channel} not in range ({nch} channels supported)".format(
                     channel=channel,
@@ -233,7 +234,8 @@ class Tenma72Base(object):
             :param mV: Voltage to check
             :raises TenmaException: If the voltage is outside the range for the power supply
         """
-        if mV > self.MAX_MV:
+        mV = int(mV)
+        if mV > self.MAX_MV or mV < 0:
             raise TenmaException(
                 "Trying to set CH{channel} voltage to {mv}mV, the maximum is {max}mV".format(
                     channel=channel,
@@ -248,7 +250,8 @@ class Tenma72Base(object):
             :param mA: current to check
             :raises TenmaException: If the current is outside the range for the power supply
         """
-        if mA > self.MAX_MA:
+        mA = int(mA)
+        if mA > self.MAX_MA or mA < 0:
             raise TenmaException(
                 "Trying to set CH{channel} current to {ma}mA, the maximum is {max}mA".format(
                     channel=channel,
@@ -1185,7 +1188,8 @@ class Tenma72_13360_base(object):
             :param mV: Voltage to check
             :raises TenmaException: If the voltage is outside the range for the power supply
         """
-        if mV > self.MAX_MV:
+        mV = int(mV)
+        if mV > self.MAX_MV or mV < 0:
             raise TenmaException(
                 "Trying to set voltage to {mv}mV, the maximum is {max}mV".format(
                     mv=mV,
@@ -1198,7 +1202,8 @@ class Tenma72_13360_base(object):
             :param mA: current to check
             :raises TenmaException: If the current is outside the range for the power supply
         """
-        if mA > self.MAX_MA:
+        mA = int(mA)
+        if mA > self.MAX_MA or mA < 0:
             raise TenmaException(
                 "Trying to set current to {ma}mA, the maximum is {max}mA".format(
                     ma=mA,

--- a/tenma/tenmaDcLib.py
+++ b/tenma/tenmaDcLib.py
@@ -81,7 +81,7 @@ def findSubclassesRecursively(cls):
 class TenmaSerialHandler(object):
     """
     A small class that handles serial communication for tenma power supplies.
-    """   
+    """
 
     def __init__(self, serialPort, serial_eol, debug=False):
         self.ser = serial.Serial(port=serialPort,
@@ -145,7 +145,7 @@ class TenmaSerialHandler(object):
             print("<< ", out.strip())
 
         return out
-    
+
     def close(self):
         """
             Closes the serial port
@@ -171,7 +171,6 @@ class Tenma72Base(object):
     def __init__(self, serialPort, debug=False):
         SERIAL_EOL = ""
         self.serialHandler = TenmaSerialHandler(serialPort, serial_eol = SERIAL_EOL, debug=debug)
-        
         self.DEBUG = debug
 
     def setPort(self, serialPort):
@@ -205,7 +204,7 @@ class Tenma72Base(object):
             :return: Data read as a string
         """
         return self.serialHandler._readOutput()
-    
+
     def close(self):
         """
             Closes the serial port
@@ -786,7 +785,6 @@ class Tenma72_13320(Tenma72Base):
     def __init__(self, serialPort, debug=False):
         SERIAL_EOL = "\n"
         self.serialHandler = TenmaSerialHandler(serialPort, SERIAL_EOL, debug=debug)
-        
         self.DEBUG = debug
 
     def getStatus(self):
@@ -1140,7 +1138,7 @@ class Tenma72_13360_base(object):
     def __init__(self, serialPort, debug=False):
         SERIAL_EOL = "\n"
         self.serialHandler = TenmaSerialHandler(serialPort, SERIAL_EOL, debug=debug)
-        
+
         self.DEBUG = debug
 
     def setPort(self, serialPort):
@@ -1174,7 +1172,7 @@ class Tenma72_13360_base(object):
             :return: Data read as a string
         """
         return self.serialHandler._readOutput()
-    
+
     def close(self):
         """
             Closes the serial port
@@ -1218,7 +1216,7 @@ class Tenma72_13360_base(object):
         """
         self._sendCommand("*IDN?{}".format(serialEol))
         return self.__readOutput()
-        
+
     def getStatus(self):
         """
             Returns the power supply status as a dictionary of values
@@ -1250,7 +1248,7 @@ class Tenma72_13360_base(object):
             "beep ": "ON" if beep else "OFF",
             "lock ": "ON" if lock else "OFF",
         }
-    
+
     def readCurrent(self):
         """
             Reads the current setting
@@ -1337,7 +1335,7 @@ class Tenma72_13360_base(object):
         """
         command = "VOUT?"
         self._sendCommand(command)
-        return float(self.__readOutput())   
+        return float(self.__readOutput())
 
     def saveConf(self, conf):
         """
@@ -1355,7 +1353,7 @@ class Tenma72_13360_base(object):
 
         command = "SAV:{}".format(conf)
         self._sendCommand(command)
-    
+
     def saveConfFlow(self, conf):
         """
             Alias for saveConf as saveConf works as expected on Tenma 13360

--- a/tests/test_tenma.py
+++ b/tests/test_tenma.py
@@ -1,0 +1,123 @@
+import glob
+import os
+import pytest
+import sys
+
+import serial
+
+from tenma.tenmaDcLib import instantiate_tenma_class_from_device_response, TenmaException
+
+def forAllChannels(psu, func):
+    for channel in range(1, psu.NCHANNELS + 1):
+        # Channel 3 on these PSUs is special
+        # TODO: add specific tests for these
+        if psu.MATCH_STR in ['72-13320', '72-13330'] and channel == 3:
+            continue
+        func(channel)
+
+@pytest.fixture
+def tenma_psu():
+    port = os.getenv('TENMA_PORT', None)
+    if port:
+        psu = instantiate_tenma_class_from_device_response(port, debug=True)
+    else:
+        if sys.platform.startswith('win'):
+            ports = [f'COM{i}' for i in range(1, 256)]
+        elif sys.platform.startswith('linux') or sys.platform.startswith('cygwin'):
+            # this excludes your current terminal "/dev/tty"
+            ports = glob.glob('/dev/tty[A-Za-z]*')
+        elif sys.platform.startswith('darwin'):
+            ports = glob.glob('/dev/tty.*')
+        else:
+            raise EnvironmentError('Unsupported platform')
+        # find the port where the PSU is connected
+        for comport in ports:
+            try:
+                psu = instantiate_tenma_class_from_device_response(comport, debug=True)
+            except (OSError, serial.SerialException):
+                pass
+    # for safety, turn off the PSU
+    psu.OFF()
+    yield psu
+    psu.close()
+
+def test_psu_init(tenma_psu):
+    expectedModel = os.getenv('TENMA_MODEL', '72-2540')
+    assert expectedModel in tenma_psu.getVersion()
+
+def test_psu_voltage(tenma_psu):
+    def assertVoltage(channel):
+        assert tenma_psu.setVoltage(channel, 0) == 0
+        assert tenma_psu.setVoltage(channel, tenma_psu.MAX_MV) == float(tenma_psu.MAX_MV)/1000
+        # test invalid voltage
+        with pytest.raises(TenmaException):
+            tenma_psu.setVoltage(channel, tenma_psu.MAX_MV + 5)
+        with pytest.raises(TenmaException):
+            tenma_psu.setVoltage(channel, -1)
+    forAllChannels(tenma_psu, assertVoltage)
+    # test invalid channel
+    with pytest.raises(TenmaException):
+        tenma_psu.setVoltage(-1, tenma_psu.MAX_MV)
+    with pytest.raises(TenmaException):
+        tenma_psu.setVoltage(tenma_psu.NCHANNELS + 1, tenma_psu.MAX_MV)
+
+def test_psu_current(tenma_psu):
+    def assertCurrent(channel):
+        assert tenma_psu.setCurrent(channel, 0) == 0
+        assert tenma_psu.setCurrent(channel, tenma_psu.MAX_MA) == float(tenma_psu.MAX_MA)/1000
+        # test invalid current
+        with pytest.raises(TenmaException):
+            tenma_psu.setCurrent(channel, tenma_psu.MAX_MA + 5)
+        with pytest.raises(TenmaException):
+            tenma_psu.setCurrent(channel, -1)
+    forAllChannels(tenma_psu, assertCurrent)
+    # test invalid channel
+    with pytest.raises(TenmaException):
+        tenma_psu.setCurrent(-1, tenma_psu.MAX_MA)
+    with pytest.raises(TenmaException):
+        tenma_psu.setCurrent(tenma_psu.NCHANNELS + 1, tenma_psu.MAX_MA)
+
+def test_psu_memory(tenma_psu):
+    for slot in range (1, tenma_psu.NCONFS + 1):
+        # set voltage and current
+        tenma_psu.setVoltage(1, slot * tenma_psu.MAX_MV / 5)
+        tenma_psu.setCurrent(1, slot * tenma_psu.MAX_MA / 5)
+        tenma_psu.saveConfFlow(slot, 1)
+        # recall memory and assert voltages
+        tenma_psu.recallConf(slot)
+        assert tenma_psu.readVoltage(1) == slot * tenma_psu.MAX_MV / 5 / 1000
+        assert tenma_psu.readCurrent(1) == slot * tenma_psu.MAX_MA / 5 / 1000
+    # test invalid channels
+    with pytest.raises(TenmaException):
+        tenma_psu.saveConfFlow(1, -1)
+    with pytest.raises(TenmaException):
+        tenma_psu.saveConfFlow(1, tenma_psu.NCHANNELS + 1)
+    # test invalid slots
+    with pytest.raises(TenmaException):
+        tenma_psu.saveConfFlow(-1, 1)
+    with pytest.raises(TenmaException):
+        tenma_psu.recallConf(-1)
+    with pytest.raises(TenmaException):
+        tenma_psu.saveConfFlow(tenma_psu.NCONFS + 1, 1)
+    with pytest.raises(TenmaException):
+        tenma_psu.recallConf(tenma_psu.NCONFS + 1)
+
+def test_psu_beep(tenma_psu):
+    tenma_psu.setBEEP(True)
+    assert tenma_psu.getStatus()['BeepEnabled'] == True
+    tenma_psu.setBEEP(False)
+    assert tenma_psu.getStatus()['BeepEnabled'] == False
+
+def test_psu_on(tenma_psu):
+    # set voltage to 0 to try and be as safe as possible when turning on real PSUs
+    def zeroVoltageCurernt(channel):
+        assert tenma_psu.setVoltage(channel, 0) == 0
+        assert tenma_psu.setCurrent(channel, 0) == 0
+    def assertRunningCurrent(channel):
+        assert tenma_psu.runningCurrent(channel) == 0
+    forAllChannels(tenma_psu, zeroVoltageCurernt)
+    tenma_psu.ON()
+    assert tenma_psu.getStatus()['outEnabled'] == True
+    forAllChannels(tenma_psu, assertRunningCurrent)
+    tenma_psu.OFF()
+    assert tenma_psu.getStatus()['outEnabled'] == False


### PR DESCRIPTION
I tried to split everything into separate commits, can remove individual commits if you don't want to include them (e.g. removing trailing whitespace)

Tested everything in the new pytest file
- Version
- Voltage setting/reading
- Current setting/reading
- Memory store/recall all 5 slots
- Beep on/off
- Output on/off
- Running current/voltage