### PR TITLE
Tested on Tenma 72-2930

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Supports the following models with predefined limits:
     * 72-2550 -> Tested on HW (@kxtells)
     * 72-2705 -> Tested on HW (@ollie1400)
     * 72-2710 -> Tested on HW (r202401, renier.daudey)
-    * 72-2930 -> Set as manufacturer manual (not tested)
+    * 72-2930 -> Tested on HW (@Thomas-Vreys)
     * 72-2940 -> Set as manufacturer manual (not tested)
     * 72-13320 -> Set as manufacturer manual (not tested)
     * 72-13330 -> Tested on HW (thomas-phillips-nz)

--- a/tenma/tenmaDcLib.py
+++ b/tenma/tenmaDcLib.py
@@ -27,7 +27,7 @@
      * 72_2550 -> Tested on HW
      * 72-2705 -> Tested on HW
      * 72-2710 -> Tested on HW
-     * 72_2930 -> Set as manufacturer manual (not tested)
+     * 72_2930 -> Tested on HW
      * 72_2940 -> Set as manufacturer manual (not tested)
      * 72_13320 -> Set as manufacturer manual (not tested)
      * 72_13330 -> Tested on HW


### PR DESCRIPTION
Below are the pytest results:
```
$ TENMA_MODEL='72-2930' TENMA_PORT='/dev/ttyACM0' python3 -m pytest
=================================== test session starts ===================================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /****/tenma-serial
configfile: setup.cfg
collected 7 items                                                                         

tests/test_dclib.py .                                                               [ 14%]
tests/test_psu.py ......                                                            [100%]

==================================== warnings summary =====================================
.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:1428
  /****/tenma-serial/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:1428: PytestConfigWarning: Unknown config option: pep8ignore
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================== 7 passed, 1 warning in 23.38s ==============================
```

This work was sponsored by OIP Sensor Systems